### PR TITLE
Feature/banner

### DIFF
--- a/InnovationLabBackend.Api/Controllers/BannerController.cs
+++ b/InnovationLabBackend.Api/Controllers/BannerController.cs
@@ -72,6 +72,48 @@ namespace InnovationLabBackend.Api.Controllers
             await bannerRepo.DeleteBannerAsync(id);
             return NoContent();
         }
-    }
 
+        [HttpPatch("{id}")]
+        public async Task<ActionResult> UpdateBanner([FromRoute] Guid id, [FromForm] BannerUpdateDTO banner)
+        {
+            if (banner == null)
+            {
+                return BadRequest();
+            }
+            var updatedBanner = await bannerRepo.updateBannerAsync(id, banner);
+            if (updatedBanner == null)
+            {
+                return NotFound();
+            }
+            return NoContent();
+        }
+
+        [HttpPut("{id}/activate")]
+        public async Task<IActionResult> ActivateBanner([FromRoute] Guid id)
+        {
+            try
+            {
+                await bannerRepo.ActivateBanner(id);
+                return NoContent();
+            }
+            catch (Exception ex)
+            {
+                return NotFound($"Banner with id {id} not found." + ex);
+            }
+        }
+
+        [HttpPut("{id}/schedule")]
+        public async Task<ActionResult> ScheduleDateBanner([FromRoute]Guid id, [FromBody] DateScheduleDTO dateScheduleDTO)
+        {
+            try
+            {
+                await bannerRepo.ScheduleBannerDate(id, dateScheduleDTO);
+                return NoContent();
+            }
+            catch(Exception ex)
+            {
+                return NotFound($"Banner with id {id} not found." + ex);
+            }
+        }
+    }
 }

--- a/InnovationLabBackend.Api/Controllers/BannerController.cs
+++ b/InnovationLabBackend.Api/Controllers/BannerController.cs
@@ -65,5 +65,13 @@ namespace InnovationLabBackend.Api.Controllers
                 return NotFound(new { message = $"Banner with ID  not found." });
             return Ok(result);
         }
+
+        [HttpDelete("{id}")]
+        public async Task<ActionResult> DeleteBannerById(Guid id)
+        {
+            await bannerRepo.DeleteBannerAsync(id);
+            return NoContent();
+        }
     }
+
 }

--- a/InnovationLabBackend.Api/Controllers/BannerController.cs
+++ b/InnovationLabBackend.Api/Controllers/BannerController.cs
@@ -1,27 +1,29 @@
 ﻿using AutoMapper;
 using InnovationLabBackend.Api.Dtos.Banner;
+using InnovationLabBackend.Api.Dtos.Banners;
 using InnovationLabBackend.Api.Helper;
 using InnovationLabBackend.Api.Interfaces;
 using InnovationLabBackend.Api.Models;
 using InnovationLabBackend.Api.Repository;
 using Microsoft.AspNetCore.Mvc;
+using System.Reflection;
 
 namespace InnovationLabBackend.Api.Controllers
 {
     [ApiController]
-  
+
     [Route("api/v1/[controller]")]
     public class BannerController : ControllerBase
     {
         private readonly IBannerRepo bannerRepo;
         private readonly IUploadMedia uploadMediaHelper;
-        private readonly IMapper mapper; 
+        private readonly IMapper mapper;
 
         public BannerController(IBannerRepo bannerRepo, IUploadMedia uploadMediaHelper, IMapper mapper)
         {
             this.bannerRepo = bannerRepo;
             this.uploadMediaHelper = uploadMediaHelper;
-            this.mapper = mapper; 
+            this.mapper = mapper;
         }
 
         [HttpPost(Name = "CreateBanner")]
@@ -38,10 +40,30 @@ namespace InnovationLabBackend.Api.Controllers
             }
 
             var newBanner = mapper.Map<Banner>(bannerDto);
-            newBanner.Url = uploadMedaTypeResponse.Url; 
+            newBanner.Url = uploadMedaTypeResponse.Url;
 
             var createdBanner = await bannerRepo.CreateBannerAsync(newBanner);
             return CreatedAtAction(nameof(CreateBanner), new { id = createdBanner.Id }, createdBanner);
+        }
+
+        [HttpGet(Name = "GetAllBanners")]
+        public async Task<ActionResult<IEnumerable<BannerGetDTO>>> GetAllBanners(
+            [FromQuery] Enums.BannerType? type = null,
+            [FromQuery] DateTimeOffset? startDate = null,
+            [FromQuery] DateTimeOffset? endDate = null,
+            [FromQuery] DateTimeOffset? createdAfter = null)
+        {
+            var result = await bannerRepo.GetAllBannerAsync(type, startDate, endDate, createdAfter);
+            return Ok(result);
+        }
+
+        [HttpGet("{id}")]
+        public async Task<ActionResult<BannerGetDTO>> GetBannerById(Guid id)
+        {
+            var result = await bannerRepo.GetBannerByIdAsync(id);
+            if (result == null)
+                return NotFound(new { message = $"Banner with ID  not found." });
+            return Ok(result);
         }
     }
 }

--- a/InnovationLabBackend.Api/Dtos/Banners/BannerGetDTO.cs
+++ b/InnovationLabBackend.Api/Dtos/Banners/BannerGetDTO.cs
@@ -1,0 +1,20 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace InnovationLabBackend.Api.Dtos.Banners
+{
+    public class BannerGetDTO
+    {
+        public Guid Id { get; set; }
+        public  string? Url { get; set; }
+        public string? Type { get; set; }
+        public  string? Title { get; set; }
+        public string? SubTitle { get; set; }
+        public string? Caption { get; set; }
+        public bool Current { get; set; }
+        public int Version { get; set; }
+        public string? ParentId { get; set; }
+        public DateTimeOffset CreatedAt { get; set; }
+        public DateTimeOffset? ScheduledStart { get; set; }
+        public DateTimeOffset? ScheduledEnd { get; set; }
+    }
+}

--- a/InnovationLabBackend.Api/Dtos/Banners/BannerUpdateDTO.cs
+++ b/InnovationLabBackend.Api/Dtos/Banners/BannerUpdateDTO.cs
@@ -1,0 +1,14 @@
+﻿namespace InnovationLabBackend.Api.Dtos.Banners
+{
+    public class BannerUpdateDTO
+    {
+       
+        public string? Url { get; set; }
+        public Enums.BannerType? Type { get; set; }
+        public string? Title { get; set; }
+        public string? SubTitle { get; set; }
+        public string? Caption { get; set; }
+        public DateTimeOffset? ScheduledStart { get; set; }
+        public DateTimeOffset? ScheduledEnd { get; set; }
+    }
+}

--- a/InnovationLabBackend.Api/Dtos/Banners/DateScheduleDTO.cs
+++ b/InnovationLabBackend.Api/Dtos/Banners/DateScheduleDTO.cs
@@ -1,0 +1,8 @@
+﻿namespace InnovationLabBackend.Api.Dtos.Banners
+{
+    public class DateScheduleDTO
+    {
+        public DateTimeOffset? ScheduledStart { get; set; }
+        public DateTimeOffset? ScheduledEnd { get; set; }
+    }
+}

--- a/InnovationLabBackend.Api/Interfaces/IBannerRepo.cs
+++ b/InnovationLabBackend.Api/Interfaces/IBannerRepo.cs
@@ -12,9 +12,11 @@ namespace InnovationLabBackend.Api.Interfaces
         DateTimeOffset? startDate = null,
         DateTimeOffset? endDate = null,
         DateTimeOffset? createdAfter= null);
-
         Task<BannerGetDTO> GetBannerByIdAsync(Guid id);
         Task DeleteBannerAsync(Guid id);
+        Task<Banner> updateBannerAsync(Guid id,BannerUpdateDTO bannerUpdateDTO);
+        Task ActivateBanner(Guid id);
+        Task<Banner> ScheduleBannerDate(Guid id,DateScheduleDTO dateScheduleDTO);
        
     }
 }

--- a/InnovationLabBackend.Api/Interfaces/IBannerRepo.cs
+++ b/InnovationLabBackend.Api/Interfaces/IBannerRepo.cs
@@ -14,6 +14,7 @@ namespace InnovationLabBackend.Api.Interfaces
         DateTimeOffset? createdAfter= null);
 
         Task<BannerGetDTO> GetBannerByIdAsync(Guid id);
+        Task DeleteBannerAsync(Guid id);
        
     }
 }

--- a/InnovationLabBackend.Api/Interfaces/IBannerRepo.cs
+++ b/InnovationLabBackend.Api/Interfaces/IBannerRepo.cs
@@ -1,4 +1,5 @@
 ﻿using InnovationLabBackend.Api.Dtos.Banner;
+using InnovationLabBackend.Api.Dtos.Banners;
 using InnovationLabBackend.Api.Models;
 
 namespace InnovationLabBackend.Api.Interfaces
@@ -7,6 +8,12 @@ namespace InnovationLabBackend.Api.Interfaces
     {
         
         Task<Banner> CreateBannerAsync(Banner banner);
+        Task<IEnumerable<BannerGetDTO>> GetAllBannerAsync(Enums.BannerType? type = null,
+        DateTimeOffset? startDate = null,
+        DateTimeOffset? endDate = null,
+        DateTimeOffset? createdAfter= null);
+
+        Task<BannerGetDTO> GetBannerByIdAsync(Guid id);
        
     }
 }

--- a/InnovationLabBackend.Api/Repository/BannerRepo.cs
+++ b/InnovationLabBackend.Api/Repository/BannerRepo.cs
@@ -1,7 +1,9 @@
 ﻿using InnovationLabBackend.Api.DbContext;
 using InnovationLabBackend.Api.Dtos.Banner;
+using InnovationLabBackend.Api.Dtos.Banners;
 using InnovationLabBackend.Api.Interfaces;
 using InnovationLabBackend.Api.Models;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 
 namespace InnovationLabBackend.Api.Repository
@@ -9,11 +11,95 @@ namespace InnovationLabBackend.Api.Repository
     public class BannerRepo(InnovationLabDbContext context) : IBannerRepo
     {
         private readonly InnovationLabDbContext _dbContext = context;
+
         public async Task<Banner> CreateBannerAsync(Banner banner)
         {
             await _dbContext.Banners.AddAsync(banner);
             await _dbContext.SaveChangesAsync();
             return banner;
+        }
+
+        public async Task<IEnumerable<BannerGetDTO>> GetAllBannerAsync(
+             Enums.BannerType? type = null,
+            DateTimeOffset? startDate = null,
+            DateTimeOffset? endDate = null,
+            DateTimeOffset? createdAfter = null
+            )
+
+        {
+            var query =  _dbContext.Banners.AsNoTracking().AsQueryable();
+
+            if (type.HasValue)
+                query = query.Where(b => b.Type == type.Value);
+
+            if (startDate.HasValue)
+                query = query.Where(b => b.ScheduledStart >= startDate.Value);
+
+            if (endDate.HasValue)
+                query = query.Where(b => b.ScheduledEnd <= endDate.Value);
+
+            if (createdAfter.HasValue)
+                query = query.Where(b => b.CreatedAt >= createdAfter.Value); // yes lai ali proper banauna sakinxa
+
+            return await query
+                .Select(b => new BannerGetDTO
+                {
+                    Id = b.Id,
+                    Url = b.Url,
+                    Type = b.Type.ToString(),
+                    Title = b.Title,
+                    SubTitle = b.SubTitle,
+                    Caption = b.Caption,
+                    Current = b.Current,
+                    Version = b.Version,
+                    ParentId = b.ParentId,
+                    CreatedAt = b.CreatedAt,
+                    ScheduledStart = b.ScheduledStart,
+                    ScheduledEnd = b.ScheduledEnd
+                })
+                .ToListAsync();
+        }
+
+        public async Task<BannerGetDTO> GetBannerByIdAsync(Guid id)
+        {
+            var result= await _dbContext.Banners.AsNoTracking()
+                .Where(u => u.Id == id)
+                .Select(b=> new BannerGetDTO
+                {
+                    Id = b.Id,
+                    Url = b.Url,
+                    Type = b.Type.ToString(),
+                    Title = b.Title,
+                    SubTitle = b.SubTitle,
+                    Caption = b.Caption,
+                    Current = b.Current,
+                    Version = b.Version,
+                    ParentId = b.ParentId,
+                    CreatedAt = b.CreatedAt,
+                    ScheduledStart = b.ScheduledStart,
+                    ScheduledEnd = b.ScheduledEnd
+                }).FirstOrDefaultAsync();
+
+            if (result == null)
+                throw new NotFoundException($"Banner with ID {id} not found.");
+            return result;
+
+        }
+    }
+
+    [Serializable]
+    internal class NotFoundException : Exception
+    {
+        public NotFoundException()
+        {
+        }
+
+        public NotFoundException(string? message) : base(message)
+        {
+        }
+
+        public NotFoundException(string? message, Exception? innerException) : base(message, innerException)
+        {
         }
     }
 }

--- a/InnovationLabBackend.Api/Repository/BannerRepo.cs
+++ b/InnovationLabBackend.Api/Repository/BannerRepo.cs
@@ -5,6 +5,7 @@ using InnovationLabBackend.Api.Interfaces;
 using InnovationLabBackend.Api.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+using System.Linq;
 
 namespace InnovationLabBackend.Api.Repository
 {
@@ -17,6 +18,18 @@ namespace InnovationLabBackend.Api.Repository
             await _dbContext.Banners.AddAsync(banner);
             await _dbContext.SaveChangesAsync();
             return banner;
+        }
+
+        public Task DeleteBannerAsync(Guid id)
+        {
+            var banner = _dbContext.Banners.FirstOrDefault(b => b.Id == id);
+            if (banner == null)
+            {
+                throw new NotFoundException($"Banner with ID {id} not found.");
+            }
+
+            _dbContext.Banners.Remove(banner);
+            return _dbContext.SaveChangesAsync();
         }
 
         public async Task<IEnumerable<BannerGetDTO>> GetAllBannerAsync(
@@ -85,6 +98,8 @@ namespace InnovationLabBackend.Api.Repository
             return result;
 
         }
+
+
     }
 
     [Serializable]


### PR DESCRIPTION
## Description

It successfully perform all the crud api need for banner with best practices

### What's Included

- [x] [Successfully creates a banner]
- [x] [Successfully updates a banner]
- [x] [Successfully deletes a banner]
- [x] [Successfully gets banner]
- [ ] [Edge cases are still to be tested and discovered]

## Related Issues / Tickets

## Checklist

- [x] Code follows project structure and style guidelines
- [x] Functionality tested locally
- [ ] Includes error handling and edge case coverage
- [ ] Added/updated relevant unit/integration tests _(if applicable)_
- [ ] API routes protected if needed (auth/middleware)
- [x] No console errors or warnings
- [ ] PR reviewed by at least one other team member

## Changes Made

- [Added `POST /banners to create a baner]
- [Added `GET /banners to get all the banners]
- [Added 'PUT /banners/{id}/activate to activate a banner and deactivate others]
- [Added `PATCH banners/{id} update whole banner structure]
- [Added `GET /banners/{id} get banner by id]
- [Added 'PUT /banners/{id}/schedule Schedule a banner to be active at specific time in the future. ]
- [Added `DELETE /banners/{id}/schedule deletes a banner]

## Notes

> Right now by my assumption only one banner can be active at a time, when i banner is set to activate, it deactivates all the rest of the banners

## How to Test

1. Start the server: `dotnet run`
2. Use Postman 
3. Verify the expected output and edge cases