### PR TITLE
feat: created /faqs and /categories endpoints

### DIFF
--- a/InnovationLabBackend.Api/Controllers/CategoriesController.cs
+++ b/InnovationLabBackend.Api/Controllers/CategoriesController.cs
@@ -1,0 +1,73 @@
+﻿using AutoMapper;
+using InnovationLabBackend.Api.Dtos.Categories;
+using InnovationLabBackend.Api.Interfaces;
+using InnovationLabBackend.Api.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace InnovationLabBackend.Api.Controllers
+{
+    [ApiController]
+    [Consumes("application/json")]
+    [Produces("application/json")]
+    [Route("api/v1/[controller]")]
+    public class CategoriesController(ICategoriesRepo categoriesRepo, IMapper mapper) : ControllerBase
+    {
+        private readonly ICategoriesRepo _categoriesRepo = categoriesRepo;
+        private readonly IMapper _mapper = mapper;
+
+        [HttpGet(Name = "GetAllCategories")]
+        public async Task<ActionResult<List<CategoryResponseDto>>> GetAllCategories()
+        {
+            var categories = await _categoriesRepo.GetAllCategoriesAsync();
+            var categoryDtos = _mapper.Map<List<CategoryResponseDto>>(categories);
+            return Ok(categoryDtos);
+        }
+
+        [HttpGet("{id:guid}", Name = "GetCategoryById")]
+        public async Task<ActionResult<CategoryResponseDto>> GetCategoryById(Guid id)
+        {
+            var category = await _categoriesRepo.GetCategoryByIdAsync(id);
+            if (category is null)
+                return NotFound("Category with provided Id doesn't exist.");
+
+            var dto = _mapper.Map<CategoryResponseDto>(category);
+            return Ok(dto);
+        }
+
+        [HttpPost(Name = "CreateCategory")]
+        public async Task<ActionResult<CategoryResponseDto>> CreateCategory([FromBody] CreateCategoryDto createDto)
+        {
+            var newCategory = _mapper.Map<Category>(createDto);
+            var created = await _categoriesRepo.CreateCategoryAsync(newCategory);
+            var dto = _mapper.Map<CategoryResponseDto>(created);
+            return Ok(dto);
+        }
+
+        [HttpPut("{id:guid}", Name = "UpdateCategory")]
+        public async Task<ActionResult<CategoryResponseDto>> UpdateCategory(Guid id, [FromBody] UpdateCategoryDto updateDto)
+        {
+            var category = await _categoriesRepo.GetCategoryByIdAsync(id);
+            if (category is null)
+                return NotFound("Category with provided Id doesn't exist.");
+
+            _mapper.Map(updateDto, category);
+            var updated = await _categoriesRepo.UpdateCategoryAsync(category);
+            var dto = _mapper.Map<CategoryResponseDto>(updated);
+            return Ok(dto);
+        }
+
+        [HttpDelete("{id:guid}", Name = "DeleteCategoryById")]
+        public async Task<IActionResult> DeleteCategoryById(Guid id)
+        {
+            var category = await _categoriesRepo.GetCategoryByIdAsync(id);
+            if (category is null)
+                return NotFound("Category with provided Id doesn't exist.");
+
+            var deleted = await _categoriesRepo.DeleteCategoryAsync(category);
+            if (!deleted)
+                return StatusCode(500, "Internal server error during deletion.");
+
+            return Ok("Category deleted successfully.");
+        }
+    }
+}

--- a/InnovationLabBackend.Api/Controllers/FaqsController.cs
+++ b/InnovationLabBackend.Api/Controllers/FaqsController.cs
@@ -1,0 +1,113 @@
+﻿using AutoMapper;
+using InnovationLabBackend.Api.Dtos.Faqs;
+using InnovationLabBackend.Api.Interfaces;
+using InnovationLabBackend.Api.Models;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace InnovationLabBackend.Api.Controllers
+{
+    [ApiController]
+    [Route("api/v1/faqs")]
+    [Produces("application/json")]
+    [Consumes("application/json")]
+    public class FaqsController(IFaqsRepo faqsRepo, IMapper mapper, ICategoriesRepo categoriesRepo) : ControllerBase
+    {
+        private readonly IFaqsRepo _faqsRepo = faqsRepo;
+        private readonly IMapper _mapper = mapper;
+        private readonly ICategoriesRepo _categoriesRepo = categoriesRepo;
+
+        [HttpGet]
+        public async Task<ActionResult<PaginatedFaqResponseDto>> GetFaqs(
+            [FromQuery] string? category,
+            [FromQuery] int page = 1,
+            [FromQuery] int limit = 10,
+            [FromQuery(Name = "sort_by")] string sortBy = "created_at",
+            [FromQuery(Name = "sort_order")] string sortOrder = "desc")
+        {
+            var faqs = await _faqsRepo.GetFaqsAsync(category, sortBy, sortOrder, page, limit);
+
+            var totalItems = await _faqsRepo.GetTotalCountAsync(category);
+
+            var faqDtos = _mapper.Map<List<FaqResponseDto>>(faqs);
+
+            var response = new PaginatedFaqResponseDto
+            {
+                Page = page,
+                Limit = limit,
+                TotalItems = totalItems,
+                Data = faqDtos
+            };
+
+            return Ok(response);
+        }
+
+
+
+        [HttpGet("{id:guid}")]
+        public async Task<ActionResult<FaqResponseDto>> GetFaqById(Guid id)
+        {
+            var faq = await _faqsRepo.GetFaqByIdAsync(id);
+            if (faq == null)
+                return NotFound("FAQ with the provided ID does not exist.");
+
+            return Ok(_mapper.Map<FaqResponseDto>(faq));
+        }
+
+
+        [HttpPost]
+        [Authorize]
+        public async Task<ActionResult<FaqResponseDto>> CreateFaq([FromBody] CreateFaqDto createFaqDto)
+        {
+            var category = await _categoriesRepo.GetCategoryByIdAsync(createFaqDto.CategoryId);
+            if (category == null)
+                return BadRequest("Invalid category ID.");
+
+            var faq = _mapper.Map<Faq>(createFaqDto);
+            faq.Category = category;
+
+            var createdFaq = await _faqsRepo.CreateFaqAsync(faq);
+            var responseDto = _mapper.Map<FaqResponseDto>(createdFaq);
+
+            return CreatedAtAction(nameof(GetFaqById), new { id = createdFaq.Id }, responseDto);
+        }
+
+
+        [HttpPut("{id:guid}")]
+        [Authorize]
+        public async Task<ActionResult<FaqResponseDto>> UpdateFaq(Guid id, [FromBody] UpdateFaqDto updateFaqDto)
+        {
+            var faq = await _faqsRepo.GetFaqByIdAsync(id);
+            if (faq == null)
+                return NotFound("FAQ with the provided ID does not exist.");
+
+            var category = await _categoriesRepo.GetCategoryByIdAsync(updateFaqDto.CategoryId);
+            if (category == null)
+                return BadRequest("Invalid category ID.");
+
+            _mapper.Map(updateFaqDto, faq);
+            faq.Category = category;
+
+            var updatedFaq = await _faqsRepo.UpdateFaqAsync(faq);
+            var responseDto = _mapper.Map<FaqResponseDto>(updatedFaq);
+
+            return Ok(responseDto);
+        }
+
+
+        [HttpDelete("{id:guid}")]
+        [Authorize]
+        public async Task<IActionResult> DeleteFaq(Guid id)
+        {
+            var faq = await _faqsRepo.GetFaqByIdAsync(id);
+            if (faq == null)
+                return NotFound("FAQ with the provided ID does not exist.");
+
+            var result = await _faqsRepo.DeleteFaqAsync(faq);
+            if (!result)
+                return StatusCode(500, "An error occurred while deleting the FAQ.");
+
+            return Ok("FAQ deleted successfully.");
+        }
+    }
+}

--- a/InnovationLabBackend.Api/DbContext/InnovationLabDbContext.cs
+++ b/InnovationLabBackend.Api/DbContext/InnovationLabDbContext.cs
@@ -8,5 +8,7 @@ namespace InnovationLabBackend.Api.DbContext
     {
         public DbSet<Testimonial> Testimonials { get; set; }
         public DbSet<Banner> Banners { get; set; }
+        public DbSet<Category> Categories { get; set; }
+        public DbSet<Faq> Faqs { get; set; }
     }
 }

--- a/InnovationLabBackend.Api/Dtos/Categories/CategoryResponseDto.cs
+++ b/InnovationLabBackend.Api/Dtos/Categories/CategoryResponseDto.cs
@@ -1,0 +1,14 @@
+﻿using AutoMapper;
+using InnovationLabBackend.Api.Models;
+
+namespace InnovationLabBackend.Api.Dtos.Categories
+{
+    [AutoMap(typeof(Category), ReverseMap = true)]
+    public class CategoryResponseDto
+    {
+        public Guid Id { get; set; }
+        public required string Name { get; set; }
+        public DateTimeOffset CreatedAt { get; set; }
+        public DateTimeOffset LastUpdatedAt { get; set; }
+    }
+}

--- a/InnovationLabBackend.Api/Dtos/Categories/CreateCategoryDto.cs
+++ b/InnovationLabBackend.Api/Dtos/Categories/CreateCategoryDto.cs
@@ -1,0 +1,15 @@
+﻿using AutoMapper;
+using InnovationLabBackend.Api.Models;
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace InnovationLabBackend.Api.Dtos.Categories
+{
+    [AutoMap(typeof(Category), ReverseMap = true)]
+    public class CreateCategoryDto
+    {
+        [Required]
+        public string Name { get; set; } = string.Empty;
+        public Guid? ParentCategoryId { get; set; }
+    }
+}

--- a/InnovationLabBackend.Api/Dtos/Categories/UpdateCategoryDto.cs
+++ b/InnovationLabBackend.Api/Dtos/Categories/UpdateCategoryDto.cs
@@ -1,0 +1,15 @@
+﻿using AutoMapper;
+using InnovationLabBackend.Api.Models;
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace InnovationLabBackend.Api.Dtos.Categories
+{
+    [AutoMap(typeof(Category), ReverseMap = true)]
+    public class UpdateCategoryDto
+    {
+        [Required]
+        public string Name { get; set; } = string.Empty;
+        public Guid? ParentCategoryId { get; set; }
+    }
+}

--- a/InnovationLabBackend.Api/Dtos/Faqs/CreateFaqDto.cs
+++ b/InnovationLabBackend.Api/Dtos/Faqs/CreateFaqDto.cs
@@ -1,0 +1,19 @@
+﻿using AutoMapper;
+using InnovationLabBackend.Api.Models;
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace InnovationLabBackend.Api.Dtos.Faqs
+{
+    [AutoMap(typeof(Faq), ReverseMap = true)]
+    public class CreateFaqDto
+    {
+        [Required]
+        public string Question { get; set; } = default!;
+
+        [Required]
+        public string Answer { get; set; } = default!;
+
+        public Guid CategoryId { get; set; }
+    }
+}

--- a/InnovationLabBackend.Api/Dtos/Faqs/FaqResponseDto.cs
+++ b/InnovationLabBackend.Api/Dtos/Faqs/FaqResponseDto.cs
@@ -1,0 +1,18 @@
+﻿using AutoMapper;
+using InnovationLabBackend.Api.Models;
+using System;
+
+namespace InnovationLabBackend.Api.Dtos.Faqs
+{
+    [AutoMap(typeof(Faq), ReverseMap = true)]
+    public class FaqResponseDto
+    {
+        public Guid Id { get; set; }
+        public string Question { get; set; } = default!;
+        public string Answer { get; set; } = default!;
+        public DateTimeOffset CreatedAt { get; set; }
+        public DateTimeOffset LastUpdatedAt { get; set; }
+        public Guid CategoryId { get; set; }
+        public string CategoryName { get; set; } = default!;
+    }
+}

--- a/InnovationLabBackend.Api/Dtos/Faqs/PaginatedFaqResponseDto.cs
+++ b/InnovationLabBackend.Api/Dtos/Faqs/PaginatedFaqResponseDto.cs
@@ -1,0 +1,11 @@
+﻿namespace InnovationLabBackend.Api.Dtos.Faqs
+{
+    public class PaginatedFaqResponseDto
+    {
+        public int Page { get; set; }
+        public int Limit { get; set; }
+        public int TotalItems { get; set; }
+        public List<FaqResponseDto> Data { get; set; } = new();
+
+    }
+}

--- a/InnovationLabBackend.Api/Dtos/Faqs/UpdateFaqDto.cs
+++ b/InnovationLabBackend.Api/Dtos/Faqs/UpdateFaqDto.cs
@@ -1,0 +1,20 @@
+﻿using AutoMapper;
+using InnovationLabBackend.Api.Models;
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace InnovationLabBackend.Api.Dtos.Faqs
+{
+    [AutoMap(typeof(Faq), ReverseMap = true)]
+    public class UpdateFaqDto
+    {
+        [Required]
+        public string Question { get; set; } = default!;
+
+        [Required]
+        public string Answer { get; set; } = default!;
+
+        [Required]
+        public Guid CategoryId { get; set; }
+    }
+}

--- a/InnovationLabBackend.Api/Enums/CategoryType.cs
+++ b/InnovationLabBackend.Api/Enums/CategoryType.cs
@@ -1,0 +1,8 @@
+﻿namespace InnovationLabBackend.Api.Enums
+{
+    public enum CategoryType
+    {
+        Faq,
+        Gallery,
+    }
+}

--- a/InnovationLabBackend.Api/Interfaces/ICategoriesRepo.cs
+++ b/InnovationLabBackend.Api/Interfaces/ICategoriesRepo.cs
@@ -1,0 +1,18 @@
+﻿using InnovationLabBackend.Api.Models;
+
+namespace InnovationLabBackend.Api.Interfaces
+{
+    public interface ICategoriesRepo
+    {
+        Task<bool> SaveChangesAsync();
+
+        Task<List<Category>> GetAllCategoriesAsync();
+        Task<List<Category>> GetTopLevelCategoriesAsync();
+        Task<List<Category>> SearchCategoriesByNameAsync(string keyword);
+        Task<Category?> GetCategoryByIdAsync(Guid id);
+
+        Task<Category> CreateCategoryAsync(Category category);
+        Task<Category> UpdateCategoryAsync(Category category);
+        Task<bool> DeleteCategoryAsync(Category category);
+    }
+}

--- a/InnovationLabBackend.Api/Interfaces/IFaqsRepo.cs
+++ b/InnovationLabBackend.Api/Interfaces/IFaqsRepo.cs
@@ -1,0 +1,15 @@
+﻿using InnovationLabBackend.Api.Models;
+
+namespace InnovationLabBackend.Api.Interfaces
+{
+    public interface IFaqsRepo
+    {
+        Task<bool> SaveChangesAsync();
+        Task<List<Faq>> GetFaqsAsync(string? category, string sortBy, string sortOrder, int page, int limit);
+        Task<Faq?> GetFaqByIdAsync(Guid id);
+        Task<Faq> CreateFaqAsync(Faq faq);
+        Task<Faq> UpdateFaqAsync(Faq faq);
+        Task<bool> DeleteFaqAsync(Faq faq);
+        Task<int> GetTotalCountAsync(string? category);
+    }
+}

--- a/InnovationLabBackend.Api/Models/Category.cs
+++ b/InnovationLabBackend.Api/Models/Category.cs
@@ -1,0 +1,28 @@
+﻿using InnovationLabBackend.Api.Enums;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace InnovationLabBackend.Api.Models
+{
+    public class Category
+    {
+        public Guid Id { get; set; } = Guid.NewGuid();
+
+        [Required]
+        public required string Name { get; set; }
+
+        public DateTimeOffset CreatedAt { get; set; }
+        public DateTimeOffset LastUpdatedAt { get; set; }
+
+        // Parent category reference (nullable for top-level categories)
+        public Guid? ParentCategoryId { get; set; }
+
+        [ForeignKey("ParentCategoryId")]
+        public Category? ParentCategory { get; set; }
+
+        // Collection of subcategories (children)
+        public ICollection<Category> Subcategories { get; set; } = new List<Category>();
+
+        public ICollection<Faq> Faqs { get; set; } = new List<Faq>();
+    }
+}

--- a/InnovationLabBackend.Api/Models/Faq.cs
+++ b/InnovationLabBackend.Api/Models/Faq.cs
@@ -1,0 +1,23 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace InnovationLabBackend.Api.Models
+{
+    public class Faq
+    {
+        [Key]
+        public Guid Id { get; set; } = Guid.NewGuid();
+
+        [Required]
+        public required string Question { get; set; }
+        [Required]
+        public required string Answer { get; set; }
+
+        public DateTimeOffset CreatedAt { get; set; } = DateTimeOffset.UtcNow;
+        public DateTimeOffset LastUpdatedAt { get; set; } = DateTimeOffset.UtcNow;
+
+        [ForeignKey(nameof(Category))]
+        public Guid CategoryId { get; set; }
+        public Category Category { get; set; } = default!;
+    }
+}

--- a/InnovationLabBackend.Api/Program.cs
+++ b/InnovationLabBackend.Api/Program.cs
@@ -112,8 +112,8 @@ builder.Services.AddAuthorization();
 builder.Services.AddScoped<ITestimonialsRepo, TestimonialsRepo>();
 builder.Services.AddScoped<IBannerRepo, BannerRepo>();
 builder.Services.AddScoped<IUploadMedia,UploadMedia >();
-
-
+builder.Services.AddScoped<ICategoriesRepo, CategoriesRepo>();
+builder.Services.AddScoped<IFaqsRepo, FaqsRepo>();
 
 var app = builder.Build();
 

--- a/InnovationLabBackend.Api/Repository/CategoriesRepo.cs
+++ b/InnovationLabBackend.Api/Repository/CategoriesRepo.cs
@@ -1,0 +1,69 @@
+﻿using InnovationLabBackend.Api.DbContext;
+using InnovationLabBackend.Api.Interfaces;
+using InnovationLabBackend.Api.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace InnovationLabBackend.Api.Repository
+{
+    public class CategoriesRepo(InnovationLabDbContext _dbContext) : ICategoriesRepo
+    {
+        public async Task<bool> SaveChangesAsync()
+        {
+            return await _dbContext.SaveChangesAsync() > 0;
+        }
+
+        public async Task<List<Category>> GetAllCategoriesAsync()
+        {
+            return await _dbContext.Categories
+                .Include(c => c.Subcategories)
+                .ToListAsync();
+        }
+
+        public async Task<List<Category>> GetTopLevelCategoriesAsync()
+        {
+            return await _dbContext.Categories
+                .Where(c => c.ParentCategoryId == null)
+                .Include(c => c.Subcategories)
+                .ToListAsync();
+        }
+
+        public async Task<List<Category>> SearchCategoriesByNameAsync(string keyword)
+        {
+            return await _dbContext.Categories
+                .Where(c => c.Name.Contains(keyword))
+                .Include(c => c.Subcategories)
+                .ToListAsync();
+        }
+
+        public async Task<Category?> GetCategoryByIdAsync(Guid id)
+        {
+            return await _dbContext.Categories
+                .Include(c => c.Subcategories)
+                .FirstOrDefaultAsync(c => c.Id == id);
+        }
+
+        public async Task<Category> CreateCategoryAsync(Category category)
+        {
+            category.CreatedAt = DateTimeOffset.UtcNow;
+            category.LastUpdatedAt = DateTimeOffset.UtcNow;
+
+            var entry = await _dbContext.Categories.AddAsync(category);
+            await SaveChangesAsync();
+            return entry.Entity;
+        }
+
+        public async Task<Category> UpdateCategoryAsync(Category category)
+        {
+            category.LastUpdatedAt = DateTimeOffset.UtcNow;
+            _dbContext.Categories.Update(category);
+            await SaveChangesAsync();
+            return category;
+        }
+
+        public async Task<bool> DeleteCategoryAsync(Category category)
+        {
+            _dbContext.Categories.Remove(category);
+            return await SaveChangesAsync();
+        }
+    }
+}

--- a/InnovationLabBackend.Api/Repository/FaqsRepo.cs
+++ b/InnovationLabBackend.Api/Repository/FaqsRepo.cs
@@ -1,0 +1,86 @@
+﻿using InnovationLabBackend.Api.DbContext;
+using InnovationLabBackend.Api.Interfaces;
+using InnovationLabBackend.Api.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace InnovationLabBackend.Api.Repository
+{
+    public class FaqsRepo : IFaqsRepo
+    {
+        private readonly InnovationLabDbContext _dbContext;
+
+        public FaqsRepo(InnovationLabDbContext dbContext)
+        {
+            _dbContext = dbContext;
+        }
+
+        public async Task<bool> SaveChangesAsync()
+        {
+            return await _dbContext.SaveChangesAsync() > 0;
+        }
+
+        public async Task<List<Faq>> GetFaqsAsync(string? category, string sortBy, string sortOrder, int page, int limit)
+        {
+            var query = _dbContext.Faqs.Include(f => f.Category).AsQueryable();
+
+            if (!string.IsNullOrWhiteSpace(category))
+            {
+                query = query.Where(f => f.Category.Name.Equals(category, StringComparison.OrdinalIgnoreCase));
+            }
+
+            query = sortBy switch
+            {
+                "question" => sortOrder == "asc" ? query.OrderBy(f => f.Question) : query.OrderByDescending(f => f.Question),
+                _ => sortOrder == "asc" ? query.OrderBy(f => f.CreatedAt) : query.OrderByDescending(f => f.CreatedAt),
+            };
+
+            return await query.Skip((page - 1) * limit).Take(limit).ToListAsync();
+        }
+
+        public async Task<Faq?> GetFaqByIdAsync(Guid id)
+        {
+            return await _dbContext.Faqs
+                .Include(f => f.Category)
+                .FirstOrDefaultAsync(f => f.Id == id);
+        }
+
+        public async Task<Faq> CreateFaqAsync(Faq faq)
+        {
+            faq.CreatedAt = DateTimeOffset.UtcNow;
+            faq.LastUpdatedAt = DateTimeOffset.UtcNow;
+
+            var entry = await _dbContext.Faqs.AddAsync(faq);
+            await SaveChangesAsync();
+            return entry.Entity;
+        }
+
+        public async Task<Faq> UpdateFaqAsync(Faq faq)
+        {
+            faq.LastUpdatedAt = DateTimeOffset.UtcNow;
+
+            _dbContext.Faqs.Update(faq);
+            await SaveChangesAsync();
+
+            return faq;
+        }
+
+        public async Task<bool> DeleteFaqAsync(Faq faq)
+        {
+            _dbContext.Faqs.Remove(faq);
+            return await SaveChangesAsync();
+        }
+
+        public async Task<int> GetTotalCountAsync(string? category)
+        {
+            var query = _dbContext.Faqs.AsQueryable();
+
+            if (!string.IsNullOrWhiteSpace(category))
+            {
+                query = query.Where(f => f.Category.Name.Equals(category, StringComparison.OrdinalIgnoreCase));
+            }
+
+            return await query.CountAsync();
+        }
+
+    }
+}


### PR DESCRIPTION
## Description

This PR introduces the **Categories and FAQs API** with full CRUD functionality.

### What's Included:
- [x] Full CRUD for Categories (`/categories`)
- [x] Full CRUD for FAQs (`/faqs`)
- [x] Proper API structure and separation of concerns
- [ ] Authentication and protected routes (planned, not implemented)
- [ ] Persistent database integration (currently using in-memory/mock data)

## Related Issues / Tickets

None currently linked.

## Checklist

- [x] Follows project code standards and conventions
- [x] CRUD operations tested locally via Postman/cURL
- [ ] Middleware/authentication added for protected routes
- [ ] Connected to persistent database
- [x] No console errors or warnings
- [ ] Reviewed and approved by at least one team member

## Changes Made

- Added endpoints for **Categories**:
  - `POST /categories` — create category
  - `GET /categories` — list all categories
  - `GET /categories/:id` — get category by ID
  - `PUT /categories/:id` — update category
  - `DELETE /categories/:id` — delete category

- Added endpoints for **FAQs**:
  - `POST /faqs` — create FAQ (validates category)
  - `GET /faqs` — list FAQs with pagination, category filter, and sorting
  - `GET /faqs/:id` — get FAQ by ID
  - `PUT /faqs/:id` — update FAQ (validates category)
  - `DELETE /faqs/:id` — delete FAQ

## Notes

> Protected routes (e.g. with `[Authorize]`) are **planned but not implemented** yet.

> Database operations currently use in-memory or mock data and can be swapped with a persistent store in the future.


## How to Test

1. Start the server: `dotnet run`
2. Use Postman or browser to test the following:
   - `GET /example`
   - `POST /example`
   - [List more testable endpoints or behaviors]
3. Verify the expected output and edge cases